### PR TITLE
fixed wrong name on varible in compute demo_node output

### DIFF
--- a/aws/modules/compute/nodes/demo_node/output.tf
+++ b/aws/modules/compute/nodes/demo_node/output.tf
@@ -1,3 +1,3 @@
 # outputs produced at the end of a terraform apply: e.g. the id and ip of an instance
 output "demo_node_id"    { value = "${join(",", aws_instance.demo-node.*.id)}" }
-output "demo_node_sg_id" { value = "${join(",", aws_instance.demo-node.*.public_ip)}" }
+output "demo_node_ip" { value = "${join(",", aws_instance.demo-node.*.public_ip)}" }


### PR DESCRIPTION
Error: output.demo_node_ip: missing dependency: module.demo-node.output.demo_node_ip

The output.tf in terraform-best-practice/aws/environments/dev/compute calls output "demo_node_ip" { value = "${module.demo-node.demo_node_ip}" } but that does not exist in the module output. The variable is wrongly named demo_node_sg_id in ./../../modules/compute/nodes/demo_node/output.tf
